### PR TITLE
キャンバスの移動・拡縮・回転の実装

### DIFF
--- a/front/components/ImageView.vue
+++ b/front/components/ImageView.vue
@@ -42,36 +42,63 @@ onBeforeUnmount(() => {
 })
 
 let dragging = false
+let panning = { panning: false, x: 0, y: 0 }
 const dragstart = (e: PointerEvent) => {
-  dragging = true
-  const [x, y] = convert(e.offsetX, e.offsetY)
-  stroke({
-    x,
-    y,
-    pressure: e.pressure,
-  })
+  switch (e.buttons) {
+    case 1:
+      dragging = true
+      const [x, y] = convert(e.offsetX, e.offsetY)
+      stroke({
+        x,
+        y,
+        pressure: e.pressure,
+      })
+      break
+    case 4:
+      panning = {
+        panning: true,
+        x: e.offsetX,
+        y: e.offsetY,
+      }
+      break;
+  }
 }
 
 const dragmove = (e: PointerEvent) => {
-  if (!dragging) return
-  const [x, y] = convert(e.offsetX, e.offsetY)
-  stroke({
-    x,
-    y,
-    pressure: e.pressure,
-  })
-
+  switch (e.buttons) {
+    case 1:
+      if (!dragging) return
+      const [x, y] = convert(e.offsetX, e.offsetY)
+      stroke({
+        x,
+        y,
+        pressure: e.pressure,
+      })
+      break
+    case 4:
+      if (!panning.panning) return
+      cx.value += e.offsetX - panning.x
+      cy.value += e.offsetY - panning.y
+      panning.x = e.offsetX
+      panning.y = e.offsetY
+      break
+  }
 }
 
 const dragend = (e: PointerEvent) => {
-  if (!dragging) return
-  const [x, y] = convert(e.offsetX, e.offsetY)
-  stroke({
-    x,
-    y,
-    pressure: e.pressure,
-  })
-  dragging = false
+  if (dragging) {
+    const [x, y] = convert(e.offsetX, e.offsetY)
+    stroke({
+      x,
+      y,
+      pressure: e.pressure,
+    })
+    dragging = false
+  }
+  if (panning.panning) {
+    panning.panning = false
+  }
+
 }
 
 const convert = (x: number, y: number) => {

--- a/front/components/ImageView.vue
+++ b/front/components/ImageView.vue
@@ -53,6 +53,7 @@ const redraw = () => {
   const ih = imageData.value.height
   if (buffcanvas.value === undefined) return
   if (viewcanvas.value === undefined) return
+  if (viewctx.value === undefined) return
   buffcanvas.value.width = iw
   buffcanvas.value.height = ih
   buffctx.value?.putImageData(imageData.value, 0, 0)
@@ -64,6 +65,15 @@ const redraw = () => {
   viewcanvas.value.width = cw
   viewcanvas.value.height = ch
   viewctx.value?.clearRect(0, 0, cw, ch)
+  viewctx.value.fillStyle = 'rgb(192, 192, 192)'
+  viewctx.value?.fillRect(0, 0, iw, ih)
+  viewctx.value.fillStyle = 'rgb(255, 255, 255)'
+  for (let w = 0; w < iw; w += 8) {
+    for (let h = 0; h < ih; h += 8) {
+      if ((w & 8) === (h & 8)) continue
+      viewctx.value.fillRect(w, h, Math.min(iw, w + 8) - w, Math.min(ih, h + 8) - h)
+    }
+  }
   viewctx.value?.drawImage(buffcanvas.value, 0, 0, w, h, 0, 0, w, h)
 }
 

--- a/front/components/ImageView.vue
+++ b/front/components/ImageView.vue
@@ -43,18 +43,20 @@ onBeforeUnmount(() => {
 let dragging = false
 const dragstart = (e: PointerEvent) => {
   dragging = true
+  const [x, y] = convert(e.offsetX, e.offsetY)
   stroke({
-    x: e.offsetX - left.value,
-    y: e.offsetY - top.value,
+    x,
+    y,
     pressure: e.pressure,
   })
 }
 
 const dragmove = (e: PointerEvent) => {
   if (!dragging) return
+  const [x, y] = convert(e.offsetX, e.offsetY)
   stroke({
-    x: e.offsetX - left.value,
-    y: e.offsetY - top.value,
+    x,
+    y,
     pressure: e.pressure,
   })
 
@@ -62,12 +64,27 @@ const dragmove = (e: PointerEvent) => {
 
 const dragend = (e: PointerEvent) => {
   if (!dragging) return
+  const [x, y] = convert(e.offsetX, e.offsetY)
   stroke({
-    x: e.offsetX - left.value,
-    y: e.offsetY - top.value,
+    x,
+    y,
     pressure: e.pressure,
   })
   dragging = false
+}
+
+const convert = (x: number, y: number) => {
+  const iw = imageData.value.width
+  const ih = imageData.value.height
+  const ox = left.value + iw / 2
+  const oy = top.value + ih / 2
+  const c = Math.cos(angle.value)
+  const s = Math.sin(angle.value)
+  const dx = c * ox + s * oy - iw / 2
+  const dy = -s * ox + c * oy - ih / 2
+  const x0 = c * x + s * y - dx
+  const y0 = -s * x + c * y - dy
+  return [x0, y0]
 }
 
 const redraw = () => {

--- a/front/components/ImageView.vue
+++ b/front/components/ImageView.vue
@@ -200,8 +200,8 @@ const decAngle = () => {
       <button @click="decAngle" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">-</button>
     </div>
     <div class="h-full bg-slate-100">
-      <canvas ref="viewcanvas" class="w-full h-full" @pointerdown="dragstart" @pointermove="dragmove"
-        @pointerup="dragend"></canvas>
+      <canvas ref="viewcanvas" class="w-full h-full" @pointerdown.prevent="dragstart" @pointermove.prevent="dragmove"
+        @pointerup.prevent="dragend"></canvas>
     </div>
     <canvas ref="buffcanvas" class="hidden"></canvas>
   </div>

--- a/front/components/ImageView.vue
+++ b/front/components/ImageView.vue
@@ -11,10 +11,10 @@ const { modify, stroke } = useImage(imageData)
 
 onMounted(() => {
   if (viewcanvas.value === undefined) throw new Error('canvasを初期化できませんでした');
-  viewctx.value = viewcanvas.value.getContext('2d') || undefined
+  viewctx.value = viewcanvas.value.getContext('2d', { desynchronized: true }) || undefined
 
   if (buffcanvas.value === undefined) throw new Error('canvas?')
-  buffctx.value = buffcanvas.value.getContext('2d') || undefined
+  buffctx.value = buffcanvas.value.getContext('2d', { desynchronized: false }) || undefined
 })
 
 let dragging = false
@@ -76,12 +76,8 @@ watchEffect(redraw)
       <button @click="modify" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">redraw</button>
     </div>
     <div class="h-full bg-slate-100">
-      <canvas
-        ref="viewcanvas" class="w-full h-full"
-        @pointerdown="dragstart"
-        @pointermove="dragmove"
-        @pointerup="dragend"
-      ></canvas>
+      <canvas ref="viewcanvas" class="w-full h-full" @pointerdown="dragstart" @pointermove="dragmove"
+        @pointerup="dragend"></canvas>
     </div>
     <canvas ref="buffcanvas" class="hidden"></canvas>
   </div>

--- a/front/components/ImageView.vue
+++ b/front/components/ImageView.vue
@@ -9,12 +9,29 @@ const height = 300
 const imageData = ref(new ImageData(width, height))
 const { modify, stroke } = useImage(imageData)
 
+const cw = ref(0)
+const ch = ref(0)
+const onWindowResize = () => {
+  if (viewcanvas.value === undefined) return
+  cw.value = viewcanvas.value.clientWidth ?? 0
+  ch.value = viewcanvas.value.clientHeight ?? 0
+  viewcanvas.value.width = cw.value
+  viewcanvas.value.height = ch.value
+}
+
 onMounted(() => {
   if (viewcanvas.value === undefined) throw new Error('canvasを初期化できませんでした');
   viewctx.value = viewcanvas.value.getContext('2d', { desynchronized: true }) || undefined
 
   if (buffcanvas.value === undefined) throw new Error('canvas?')
   buffctx.value = buffcanvas.value.getContext('2d', { desynchronized: false }) || undefined
+
+  window.addEventListener('resize', onWindowResize)
+  onWindowResize()
+})
+
+onBeforeUnmount(() => {
+  window.addEventListener('resize', onWindowResize)
 })
 
 let dragging = false
@@ -58,13 +75,9 @@ const redraw = () => {
   buffcanvas.value.height = ih
   buffctx.value?.putImageData(imageData.value, 0, 0)
 
-  const cw = viewcanvas.value.clientWidth
-  const ch = viewcanvas.value.clientHeight
-  const w = Math.min(cw, iw)
-  const h = Math.min(ch, ih)
-  viewcanvas.value.width = cw
-  viewcanvas.value.height = ch
-  viewctx.value?.clearRect(0, 0, cw, ch)
+  const w = Math.min(cw.value, iw)
+  const h = Math.min(ch.value, ih)
+  viewctx.value?.clearRect(0, 0, cw.value, ch.value)
   viewctx.value.fillStyle = 'rgb(192, 192, 192)'
   viewctx.value?.fillRect(0, 0, iw, ih)
   viewctx.value.fillStyle = 'rgb(255, 255, 255)'

--- a/front/components/ImageView.vue
+++ b/front/components/ImageView.vue
@@ -19,6 +19,9 @@ const onWindowResize = () => {
   viewcanvas.value.height = ch.value
 }
 
+const left = ref(0)
+const top = ref(0)
+
 onMounted(() => {
   if (viewcanvas.value === undefined) throw new Error('canvasを初期化できませんでした');
   viewctx.value = viewcanvas.value.getContext('2d', { desynchronized: true }) || undefined
@@ -28,6 +31,8 @@ onMounted(() => {
 
   window.addEventListener('resize', onWindowResize)
   onWindowResize()
+  left.value = (cw.value - width) / 2
+  top.value = (ch.value - height)  / 2
 })
 
 onBeforeUnmount(() => {
@@ -38,8 +43,8 @@ let dragging = false
 const dragstart = (e: PointerEvent) => {
   dragging = true
   stroke({
-    x: e.offsetX,
-    y: e.offsetY,
+    x: e.offsetX - left.value,
+    y: e.offsetY - top.value,
     pressure: e.pressure,
   })
 }
@@ -47,8 +52,8 @@ const dragstart = (e: PointerEvent) => {
 const dragmove = (e: PointerEvent) => {
   if (!dragging) return
   stroke({
-    x: e.offsetX,
-    y: e.offsetY,
+    x: e.offsetX - left.value,
+    y: e.offsetY - top.value,
     pressure: e.pressure,
   })
 
@@ -57,8 +62,8 @@ const dragmove = (e: PointerEvent) => {
 const dragend = (e: PointerEvent) => {
   if (!dragging) return
   stroke({
-    x: e.offsetX,
-    y: e.offsetY,
+    x: e.offsetX - left.value,
+    y: e.offsetY - top.value,
     pressure: e.pressure,
   })
   dragging = false
@@ -79,15 +84,15 @@ const redraw = () => {
   const h = Math.min(ch.value, ih)
   viewctx.value?.clearRect(0, 0, cw.value, ch.value)
   viewctx.value.fillStyle = 'rgb(192, 192, 192)'
-  viewctx.value?.fillRect(0, 0, iw, ih)
+  viewctx.value?.fillRect(left.value, top.value, iw, ih)
   viewctx.value.fillStyle = 'rgb(255, 255, 255)'
   for (let w = 0; w < iw; w += 8) {
     for (let h = 0; h < ih; h += 8) {
       if ((w & 8) === (h & 8)) continue
-      viewctx.value.fillRect(w, h, Math.min(iw, w + 8) - w, Math.min(ih, h + 8) - h)
+      viewctx.value.fillRect(w + left.value, h + top.value, Math.min(iw, w + 8) - w, Math.min(ih, h + 8) - h)
     }
   }
-  viewctx.value?.drawImage(buffcanvas.value, 0, 0, w, h, 0, 0, w, h)
+  viewctx.value?.drawImage(buffcanvas.value, 0, 0, w, h, left.value, top.value, w, h)
 }
 
 watchEffect(redraw)

--- a/front/components/ImageView.vue
+++ b/front/components/ImageView.vue
@@ -21,6 +21,7 @@ const onWindowResize = () => {
 
 const left = ref(0)
 const top = ref(0)
+const angle = ref(Math.PI / 32)
 
 onMounted(() => {
   if (viewcanvas.value === undefined) throw new Error('canvasを初期化できませんでした');
@@ -32,7 +33,7 @@ onMounted(() => {
   window.addEventListener('resize', onWindowResize)
   onWindowResize()
   left.value = (cw.value - width) / 2
-  top.value = (ch.value - height)  / 2
+  top.value = (ch.value - height) / 2
 })
 
 onBeforeUnmount(() => {
@@ -83,25 +84,45 @@ const redraw = () => {
   const w = Math.min(cw.value, iw)
   const h = Math.min(ch.value, ih)
   viewctx.value?.clearRect(0, 0, cw.value, ch.value)
+
+  viewctx.value?.save()
+  const ox = left.value + iw / 2
+  const oy = top.value + ih / 2
+  const c = Math.cos(angle.value)
+  const s = Math.sin(angle.value)
+  const dx = c * ox + s * oy - iw / 2
+  const dy = -s * ox + c * oy - ih / 2
+  viewctx.value?.transform(c, s, -s, c, c * dx - s * dy, s * dx + c * dy)
   viewctx.value.fillStyle = 'rgb(192, 192, 192)'
-  viewctx.value?.fillRect(left.value, top.value, iw, ih)
+  viewctx.value?.fillRect(0, 0, iw, ih)
   viewctx.value.fillStyle = 'rgb(255, 255, 255)'
   for (let w = 0; w < iw; w += 8) {
     for (let h = 0; h < ih; h += 8) {
       if ((w & 8) === (h & 8)) continue
-      viewctx.value.fillRect(w + left.value, h + top.value, Math.min(iw, w + 8) - w, Math.min(ih, h + 8) - h)
+      viewctx.value.fillRect(w, h, Math.min(iw, w + 8) - w, Math.min(ih, h + 8) - h)
     }
   }
-  viewctx.value?.drawImage(buffcanvas.value, 0, 0, w, h, left.value, top.value, w, h)
+  viewctx.value?.drawImage(buffcanvas.value, 0, 0, w, h, 0, 0, w, h)
+  viewctx.value?.restore()
 }
 
 watchEffect(redraw)
+
+const incAngle = () => {
+  angle.value += 0.01
+}
+
+const decAngle = () => {
+  angle.value -= 0.01
+}
 </script>
 
 <template>
   <div class="w-full h-screen flex flex-col">
     <div class="p-2 flex flex-row gap-2 bg-slate-200">
       <button @click="modify" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">redraw</button>
+      <button @click="incAngle" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">+</button>
+      <button @click="decAngle" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">-</button>
     </div>
     <div class="h-full bg-slate-100">
       <canvas ref="viewcanvas" class="w-full h-full" @pointerdown="dragstart" @pointermove="dragmove"


### PR DESCRIPTION
キャンバスを移動・拡縮・回転できるようにしました。
まだUIは整えていないので、移動は中ボタンドラッグ、回転は+ / -ボタンでしか行えません。
拡縮に至っては全くできません。

UIの改良の前に表示位置の状態をstoreに切り出すほうが良さそう。