### PR TITLE
LayerクラスをRustに移植する再挑戦

### DIFF
--- a/front/composables/useImage.ts
+++ b/front/composables/useImage.ts
@@ -1,10 +1,8 @@
 import { UndoBuffer } from "./UndoBuffer";
-import type { Layer } from "./Layers";
 import init, { Layer as WasmLayer } from '@/assets/wasm/wasm'
 
 let memory: WebAssembly.Memory;
 memory = (await init()).memory
-// console.log(memory)
 
 export interface Position {
   x: number;
@@ -25,15 +23,6 @@ let imageData: ImageData
 let undoBuffer: UndoBuffer<ImageData>
 let requestId = 0
 
-// let layer: WasmLayer
-// function newlayer() {
-//   const width = 8
-//   const height = 16
-//   layer = WasmLayer.new(width, height)
-//   const pixelsPtr = layer.get_pixels()
-//   const pixels = new Uint8ClampedArray(memory.buffer, pixelsPtr, width * height * 4);
-//   console.log(pixels)
-// }
 export const useImage = () => {
   // やっぱりImageDataが使えないよって文句言ってるんだ！！
   // SSRを切ればImageDataも使えそうだ！！
@@ -47,14 +36,8 @@ export const useImage = () => {
     h.value = height
     buffcanvas.value = new OffscreenCanvas(width, height)
     buffctx.value = buffcanvas.value.getContext("2d") ?? undefined
-    // layers = new ImageFolder(width, height)
     layers = WasmLayer.new(width, height)
 
-    // const baseLayer = new ColorImage(width, height)
-    // baseLayer.image.fill(255)
-    // layers.add(baseLayer)
-    // layers.add(new ColorImage(width, height))
-    // pixel = layers.image
     const pixelsPtr = layers.pixels()
     console.log(pixelsPtr)
     console.log(memory.buffer)
@@ -68,7 +51,6 @@ export const useImage = () => {
 
   const stroke = (pos: Position): void => {
     if (w.value === undefined || h.value === undefined) return
-    // console.log(pos)
     layers.stroke(pos.x, pos.y, pos.pressure)
   }
 
@@ -76,8 +58,6 @@ export const useImage = () => {
     // const image = undoBuffer.undo()
     // if (image === undefined) return
     // imageData.data.set(image.data)
-    // newlayer()
-    // await layers.redraw()
   }
 
   function redo() {
@@ -89,13 +69,6 @@ export const useImage = () => {
   const redraw = () => {
     if (layers === undefined) return
     if (pixel === undefined) return
-    // const pixelsPtr = layers.pixels()
-    // // console.log(pixelsPtr)
-    // // console.log(memory.buffer)
-    // pixel = new Uint8ClampedArray(memory.buffer, pixelsPtr, w.value * h.value * 4);
-    // // console.log(pixel.slice(0, 32))
-
-    // imageData = new ImageData(pixel, w.value, h.value)
     buffctx.value?.putImageData(imageData, 0, 0)
 
     requestId = requestAnimationFrame(redraw)

--- a/front/composables/useImage.ts
+++ b/front/composables/useImage.ts
@@ -39,10 +39,7 @@ export const useImage = () => {
     layers = WasmLayer.new(width, height)
 
     const pixelsPtr = layers.pixels()
-    console.log(pixelsPtr)
-    console.log(memory.buffer)
     pixel = new Uint8ClampedArray(memory.buffer, pixelsPtr, width * height * 4);
-    console.log(pixel)
     imageData = new ImageData(pixel, width, height)
     // undoBuffer = new UndoBuffer<ImageData>(
     //   new ImageData(new Uint8ClampedArray(pixel), width)

--- a/front/composables/useImage.ts
+++ b/front/composables/useImage.ts
@@ -1,6 +1,6 @@
 import { UndoBuffer } from "./UndoBuffer";
 import type { Layer } from "./Layers";
-import init, { SimpleLayer as WasmLayer } from '@/assets/wasm/wasm'
+import init, { Layer as WasmLayer } from '@/assets/wasm/wasm'
 
 let memory: WebAssembly.Memory;
 memory = (await init()).memory
@@ -77,7 +77,7 @@ export const useImage = () => {
     // if (image === undefined) return
     // imageData.data.set(image.data)
     // newlayer()
-    await layers.redraw()
+    // await layers.redraw()
   }
 
   function redo() {

--- a/wasm/src/layer.rs
+++ b/wasm/src/layer.rs
@@ -30,7 +30,7 @@ pub struct Layer {
 
 #[wasm_bindgen]
 impl Layer {
-    pub fn new(width: u16, height: u16) -> Layer {
+    pub fn new(width: i32, height: i32) -> Layer {
         Layer {
             data: Box::new(color_image::ColorImage::new(width, height)),
         }

--- a/wasm/src/layer.rs
+++ b/wasm/src/layer.rs
@@ -1,6 +1,5 @@
 pub mod color_image;
 
-use color_image::ColorImage;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[derive(Debug)]
@@ -12,12 +11,8 @@ pub struct BoundingBox {
 }
 
 pub trait ImageLayer {
-    fn new(width: u16, height: u16) -> Self;
     fn stroke(&mut self, x: f64, y: f64, pressure: f64) -> BoundingBox;
-}
-
-enum LayerType {
-    ColorImage(ColorImage),
+    fn pixels(&self) -> *const u8;
 }
 
 #[wasm_bindgen]
@@ -30,33 +25,22 @@ pub struct Position {
 
 #[wasm_bindgen]
 pub struct Layer {
-    data: LayerType,
+    data: Box<dyn ImageLayer>,
 }
 
 #[wasm_bindgen]
 impl Layer {
     pub fn new(width: u16, height: u16) -> Layer {
         Layer {
-            data: LayerType::ColorImage(color_image::ColorImage::new(width, height)),
+            data: Box::new(color_image::ColorImage::new(width, height)),
         }
     }
 
-    pub fn len(&self) -> usize {
-        match &self.data {
-            LayerType::ColorImage(v) => v.pixels.len(),
-        }
-    }
-
-    pub fn get_pixels(&self) -> *const u8 {
-        match &self.data {
-            LayerType::ColorImage(v) => v.pixels.as_ptr(),
-        }
+    pub fn pixels(&self) -> *const u8 {
+        self.data.pixels()
     }
 
     pub fn stroke(&mut self, x: f64, y: f64, pressure: f64) {
-        println!("{}, {}, {}", x, y, pressure);
-        match &mut self.data {
-            LayerType::ColorImage(v) => v.stroke(x, y, pressure)
-        };
+        self.data.stroke(x, y, pressure);
     }
 }

--- a/wasm/src/layer/color_image.rs
+++ b/wasm/src/layer/color_image.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 
 #[derive(Debug)]
 pub struct ColorImage {
-    pub pixels: Vec<u8>,
+    pixels: Vec<u8>,
     width: u16,
     height: u16,
     is_drawing: bool,
@@ -11,21 +11,6 @@ pub struct ColorImage {
 }
 
 impl ImageLayer for ColorImage {
-    fn new(width: u16, height: u16) -> ColorImage {
-        let length: usize = (width * height * 4).try_into().unwrap();
-        ColorImage {
-            pixels: vec![0; length],
-            width: width,
-            height: height,
-            is_drawing: false,
-            previouse_pos: super::Position {
-                x: 0.0,
-                y: 0.0,
-                pressure: 0.0,
-            },
-        }
-    }
-
     fn stroke(&mut self, x: f64, y: f64, pressure: f64) -> BoundingBox {
         let mut result = BoundingBox {
             left: 0,
@@ -39,14 +24,11 @@ impl ImageLayer for ColorImage {
 
                 // undoバッファに突っ込む。
             };
-            self.line(
-                &self.previouse_pos.clone(),
-                &super::Position {
-                    x: x,
-                    y: y,
-                    pressure: pressure,
-                },
-            );
+            self.line(&super::Position {
+                x: x,
+                y: y,
+                pressure: pressure,
+            });
             result = BoundingBox {
                 left: x.min(self.previouse_pos.x).floor() as u32,
                 top: y.min(self.previouse_pos.y).floor() as u32,
@@ -71,36 +53,56 @@ impl ImageLayer for ColorImage {
                 y: y,
                 pressure: pressure,
             };
-            self.plot(x, y);
+            self.plot(x.round() as i32, y.round() as i32);
         }
 
         result
     }
+
+    fn pixels(&self) -> *const u8 {
+        self.pixels.as_ptr()
+    }
 }
 
 impl ColorImage {
+    pub fn new(width: u16, height: u16) -> ColorImage {
+        let length: usize = (width as u32 * height as u32 * 4).try_into().unwrap();
+        ColorImage {
+            pixels: vec![0; length],
+            width: width,
+            height: height,
+            is_drawing: false,
+            previouse_pos: super::Position {
+                x: 0.0,
+                y: 0.0,
+                pressure: 0.0,
+            },
+        }
+    }
+
     /// p1からp2まで直線を描画する。
-    fn line(&mut self, p1: &super::Position, p2: &super::Position) {
+    fn line(&mut self, p2: &super::Position) {
+        let p1 = &self.previouse_pos;
         let x0 = p1.x.round() as i32;
         let y0 = p1.y.round() as i32;
         let x1 = p2.x.round() as i32;
         let y1 = p2.y.round() as i32;
-        let dx = x1.abs_diff(x0);
-        let dy = y1.abs_diff(y0);
+        let dx = x1.abs_diff(x0) as i32;
+        let dy = y1.abs_diff(y0) as i32;
         let sx = if x0 < x1 { 1 } else { -1 } as i32;
         let sy = if y0 < y1 { 1 } else { -1 } as i32;
-        let mut err = dx - dy;
+        let mut err = dx as i32 - dy as i32;
 
         let mut x = x0;
         let mut y = y0;
 
         loop {
-            self.plot(x as f64, y as f64);
+            self.plot(x, y);
             if x == x1 && y == y1 {
                 break;
             }
             let e2 = 2 * err;
-            if e2 as i32 > -(dy as i32) {
+            if e2 > -dy {
                 err -= dy;
                 x += sx;
             }
@@ -112,8 +114,8 @@ impl ColorImage {
     }
 
     /// 点をプロットする。
-    fn plot(&mut self, x: f64, y: f64) {
-        let idx = ((y as usize) * (self.width as usize) + (x as usize)) * 4;
+    fn plot(&mut self, x: i32, y: i32) {
+        let idx = ((y * self.width as i32 + x) * 4) as usize;
         self.pixels[idx] = 0;
         self.pixels[idx + 1] = 0;
         self.pixels[idx + 2] = 0;

--- a/wasm/src/layer/color_image.rs
+++ b/wasm/src/layer/color_image.rs
@@ -1,11 +1,12 @@
 use super::{BoundingBox, ImageLayer};
 use std::convert::TryInto;
+use crate::utils;
 
 #[derive(Debug)]
 pub struct ColorImage {
     pixels: Vec<u8>,
-    width: u16,
-    height: u16,
+    width: i32,
+    height: i32,
     is_drawing: bool,
     previouse_pos: super::Position,
 }
@@ -65,7 +66,9 @@ impl ImageLayer for ColorImage {
 }
 
 impl ColorImage {
-    pub fn new(width: u16, height: u16) -> ColorImage {
+    pub fn new(width: i32, height: i32) -> ColorImage {
+        utils::set_panic_hook();
+        // Todo: widthとheightの範囲をチェックしないといけないけどあとで。
         let length: usize = (width as u32 * height as u32 * 4).try_into().unwrap();
         ColorImage {
             pixels: vec![0; length],
@@ -115,7 +118,13 @@ impl ColorImage {
 
     /// 点をプロットする。
     fn plot(&mut self, x: i32, y: i32) {
+        if x < 0 || x > self.width || y < 0 || y > self.height {
+            return;
+        }
         let idx = ((y * self.width as i32 + x) * 4) as usize;
+        if idx > self.pixels.len() {
+            return;
+        }
         self.pixels[idx] = 0;
         self.pixels[idx + 1] = 0;
         self.pixels[idx + 2] = 0;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,7 +1,7 @@
 //! Imageを操作するWebAssembly
 //!
 //! フロントエンド側に読み込むには、
-//! ```
+//! ```ts
 //! import init, { greet } from '../assets/wasm/wasm'
 //!
 //! let memory: WebAssembly.Memory
@@ -13,7 +13,7 @@
 //!
 //! という風に初期化しておいて、
 //!
-//! ```
+//! ```ts
 //! obj = (WasmStruct).new()
 //! const ptr = obj.pixels()
 //! const length = obj.length()


### PR DESCRIPTION
SimpleLayerで線が描けたので、できるだけTypeScript側の見た目を変えずにLayer構造体を再実装します。