### PR TITLE
描画中イメージと描画前イメージを分ける

### DIFF
--- a/front/components/TheTopToolbar.vue
+++ b/front/components/TheTopToolbar.vue
@@ -30,9 +30,9 @@ async function exoprtAsPng() {
     <button @click="exoprtAsPng" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">PNG↓</button>
     <button @click="undo" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">Undo</button>
     <button @click="redo" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">Redo</button>
-    <div>
+    <div class="flex flex-row items-center">
       <label for="erase-check">消しゴム</label>
-      <input type="checkbox" id="erase-check" v-model="erase">
+      <input type="checkbox" id="erase-check" v-model="erase" class="ml-1">
     </div>
   </div>
 </template>

--- a/front/components/TheTopToolbar.vue
+++ b/front/components/TheTopToolbar.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import useViewPosition from '~/composables/imagePos';
+import { usePenState } from '~/composables/usePenState';
 
 const { buffcanvas, undo, redo } = useImage()
 const { posArray, setAngle } = useViewPosition()
+const { erase } = usePenState()
 const incAngle = () => {
   setAngle(posArray.value.angle + 0.05)
 }
@@ -28,5 +30,9 @@ async function exoprtAsPng() {
     <button @click="exoprtAsPng" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">PNG↓</button>
     <button @click="undo" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">Undo</button>
     <button @click="redo" class="px-4 h-8 bg-slate-300 border-2 border-slate-400 rounded">Redo</button>
+    <div>
+      <label for="erase-check">消しゴム</label>
+      <input type="checkbox" id="erase-check" v-model="erase">
+    </div>
   </div>
 </template>

--- a/front/composables/useImage.ts
+++ b/front/composables/useImage.ts
@@ -1,4 +1,5 @@
 import { UndoBuffer } from "./UndoBuffer";
+import { usePenState } from "./usePenState";
 import init, { Layer as WasmLayer } from '@/assets/wasm/wasm'
 
 let memory: WebAssembly.Memory;
@@ -24,6 +25,7 @@ let undoBuffer: UndoBuffer<ImageData>
 let requestId = 0
 
 export const useImage = () => {
+  const { erase } = usePenState()
   // やっぱりImageDataが使えないよって文句言ってるんだ！！
   // SSRを切ればImageDataも使えそうだ！！
   const w = useState("w", () => 0)
@@ -48,7 +50,7 @@ export const useImage = () => {
 
   const stroke = (pos: Position): void => {
     if (w.value === undefined || h.value === undefined) return
-    layers.stroke(pos.x, pos.y, pos.pressure)
+    layers.stroke(pos.x, pos.y, pos.pressure, erase.value)
   }
 
   async function undo() {

--- a/front/composables/usePenState.ts
+++ b/front/composables/usePenState.ts
@@ -1,0 +1,6 @@
+export function usePenState() {
+  const erase = useState('erase', () => false);
+  return {
+    erase
+  }
+}

--- a/wasm/src/layer.rs
+++ b/wasm/src/layer.rs
@@ -14,7 +14,7 @@ pub struct BoundingBox {
 }
 
 pub trait ImageLayer {
-    fn stroke(&mut self, x: f64, y: f64, pressure: f64) -> BoundingBox;
+    fn stroke(&mut self, x: f64, y: f64, pressure: f64, erase: bool) -> BoundingBox;
     fn pixel_pointer(&self) -> *const u8;
     fn pixel(&mut self) -> &mut Vec<u8>;
 }
@@ -56,7 +56,7 @@ impl Layer {
         self.data.pixel_pointer()
     }
 
-    pub fn stroke(&mut self, x: f64, y: f64, pressure: f64) {
-        self.data.stroke(x, y, pressure);
+    pub fn stroke(&mut self, x: f64, y: f64, pressure: f64, erase: bool) {
+        self.data.stroke(x, y, pressure, erase);
     }
 }

--- a/wasm/src/layer/folder.rs
+++ b/wasm/src/layer/folder.rs
@@ -13,9 +13,9 @@ pub struct Folder {
 }
 
 impl ImageLayer for Folder {
-    fn stroke(&mut self, x: f64, y: f64, pressure: f64) -> BoundingBox {
+    fn stroke(&mut self, x: f64, y: f64, pressure: f64, erase: bool) -> BoundingBox {
         let bb = match self.active {
-            Some(i) => self.items[i].stroke(x, y, pressure),
+            Some(i) => self.items[i].stroke(x, y, pressure, erase),
             None => BoundingBox {
                 left: 0,
                 top: 0,


### PR DESCRIPTION
描画前のImageDataを別レイヤにすることでペンの透過とかが実装しやすくなるはず。

ついでに消しゴムを実装する。